### PR TITLE
[#21] - Modify onDismiss inside of ToastProvider to fire props.onDismiss as a hook/callback

### DIFF
--- a/src/ToastProvider.js
+++ b/src/ToastProvider.js
@@ -99,8 +99,11 @@ export class ToastProvider extends Component<Props, State> {
       return { toasts };
     }, callback);
   };
-  // avoid creating a new fn on every render
-  onDismiss = (id: Id) => () => this.remove(id);
+
+  onDismiss = (id: Id, propOnDismiss: Callback = NOOP) => () => {
+    propOnDismiss(id);
+    this.remove(id);
+  };
 
   render() {
     const { children, components, ...props } = this.props;
@@ -115,11 +118,11 @@ export class ToastProvider extends Component<Props, State> {
         {canUseDOM ? (
           createPortal(
             <ToastContainer {...props}>
-              {toasts.map(({ content, id, ...rest }) => (
+              {toasts.map(({ content, id, onDismiss, ...rest }) => (
                 <ToastController
                   key={id}
                   Toast={Toast}
-                  onDismiss={this.onDismiss(id)}
+                  onDismiss={this.onDismiss(id, onDismiss)}
                   {...props}
                   {...rest}
                 >


### PR DESCRIPTION
This fixes #21 so onDismiss props are fired as a callback instead of overriding the default `onDismiss` functionality.

This code will still allow the toast to be dismissed using the close button but will write the toastId to the console:

```
toastManager.add('Here is my toast', {
      appearance: 'success',
      onDismiss(id) {
        console.log('Dismissed Toast: ', id); // "Dismissed Toast: ey78adj"
      },
    });
```