### PR TITLE
Add NODE_ENV=production to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prettier_lint": "prettier --list-different \"**/*.js\"",
     "eslint": "eslint .",
     "lint": "yarn prettier_lint && yarn eslint",
-    "build": "babel src -d dist --copy-files",
+    "build": "NODE_ENV=production babel src -d dist --copy-files",
     "prepublishOnly": "npm run build",
     "build:examples": "webpack --mode production",
     "deploy:examples": "gh-pages -d examples/dist",


### PR DESCRIPTION
Right now, babel-plugin-emotion adds source maps for styles which bloats the bundles massively. You already had a production env in babel which has emotion's source maps disabled so this just adds NODE_ENV=production to the build script.

(This isn't a thing that has to happen with babel-plugin-emotion@10 but for v9, sourceMap has to be disabled otherwise you'll get huge bundles)

Closes #15