### PR TITLE
Forward any refs passed down to withToastManager

### DIFF
--- a/src/ToastProvider.js
+++ b/src/ToastProvider.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component, type ComponentType, type Node } from 'react';
+import React, { Component, forwardRef, type ComponentType, type Node, type RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
 import { ToastController } from './ToastController';
@@ -144,8 +144,8 @@ export const ToastConsumer = ({ children }: Context => Node) => (
   <Consumer>{context => children(context)}</Consumer>
 );
 
-export const withToastManager = (Comp: ComponentType<*>) => (props: *) => (
+export const withToastManager = (Comp: ComponentType<*>) => forwardRef((props: *, ref: RefObject<*>) => (
   <ToastConsumer>
-    {context => <Comp toastManager={context} {...props} />}
+    {context => <Comp toastManager={context} {...props} ref={ref} />}
   </ToastConsumer>
-);
+));


### PR DESCRIPTION
Be sure to pass down any refs to the underlying component.

I tried doing some checking with Flow types but I haven't used flow in awhile so I was not able to validate the flow types.  There is no version of flow specified in the dev dependencies so I tried the latest version and received a bunch of errors.  Anyway...

This PR might need work to be compatible with Flow types.

If someone needs this functionality and this PR is not merged use this:
```
export const withToastManager2 = Comp =>
  React.forwardRef((props, ref) => (
    <ToastConsumer>
      {context => <Comp toastManager={context} {...props} ref={ref} />}
    </ToastConsumer>
  ));
```
