### PR TITLE
Add a removeAll method to the ToastManager to allow dismissing all active toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ The `remove` method on `ToastManager` have two arguments:
 1.  The first is the `ID` of the toast to remove.
 1.  The second is an optional callback.
 
+There's also a `removeAll` method on `ToastManager` that removes all the toasts that manager is currently managing. It takes one argument:
+
+1. An optional callback to be called when all the toasts have been removed. The callback is passed all the removed toasts `ID`s.
+
 ## Replaceable Components
 
 To bring each toast notification inline with your app, you can provide alternative components to the `ToastProvider`:

--- a/src/ToastProvider.js
+++ b/src/ToastProvider.js
@@ -100,6 +100,12 @@ export class ToastProvider extends Component<Props, State> {
     }, callback);
   };
 
+  removeAll = (cb: Callback = NOOP) => {
+    const ids = this.state.toasts;
+    const callback = () => cb(ids);
+    this.setState(state => ({ toasts: [] }), callback);
+  }
+
   onDismiss = (id: Id, cb: Callback = NOOP) => () => {
     cb(id);
     this.remove(id);
@@ -109,10 +115,10 @@ export class ToastProvider extends Component<Props, State> {
     const { children, components, ...props } = this.props;
     const { Toast, ToastContainer } = this.components;
     const { toasts } = this.state;
-    const { add, remove } = this;
+    const { add, remove, removeAll } = this;
 
     return (
-      <Provider value={{ add, remove, toasts }}>
+      <Provider value={{ add, remove, removeAll, toasts }}>
         {children}
 
         {canUseDOM ? (


### PR DESCRIPTION
This is useful for things like top level navigation or a big change in what is on screen where the toasts that might still be up pending a timer no longer make sense. If you save a resource and then navigate away to a totally different section of the app, the toast might be on top of something very different and weird. So, its handy to have an imperative way to just dismiss everything to make sure users don't get that dissonance.