### PR TITLE
Pass props through DefaultToast

### DIFF
--- a/src/ToastElement.js
+++ b/src/ToastElement.js
@@ -254,6 +254,7 @@ export const DefaultToast = ({
   transitionState,
   onMouseEnter,
   onMouseLeave,
+  ...otherProps
 }: ToastProps) => (
   <ToastElement
     appearance={appearance}
@@ -262,6 +263,7 @@ export const DefaultToast = ({
     transitionDuration={transitionDuration}
     onMouseEnter={onMouseEnter}
     onMouseLeave={onMouseLeave}
+    {...otherProps}
   >
     <Icon
       appearance={appearance}


### PR DESCRIPTION
In one of my projects, I'd like the ability to take `DefaultToast` and use it essentially as is but modify it in the slightest way (in particular, I'd like to add styles to it). `ToastElement` already passes extra props down to the inner div, so all that's needed is for `DefaultToast` to pass extra props to `ToastElement`.

Let me know your thoughts! 