### PR TITLE
Add typings for withToastManager()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,15 @@ export const DefaultToastContainer: ComponentType<ToastContainerProps>;
 export const DefaultToast: ComponentType<ToastProps>;
 export const ToastConsumer: ComponentType<ToastConsumerProps>;
 export const ToastProvider: ComponentType<ToastProviderProps>;
-export function withToastManager(...args: any[]): any;
+
+export interface ToastManagerProps {
+    toastManager: ToastConsumerContext;
+}
+
+export function withToastManager<OwnProps extends ToastManagerProps>(
+    Component: ComponentType<OwnProps>
+): ComponentType<Omit<OwnProps, keyof ToastManagerProps>>;
+
 export function useToasts(): {
     addToast: AddToast;
     removeToast: RemoveToast;


### PR DESCRIPTION
```ts
export function withToastManager(...args: any[]): any;
```

Above declaration was causing problems in inferring props of a child component of this HOC. I have added suggested type declarations for it.

This serves the purpose in my use-case, correct me if I am wrong, hope this will help.