### PR TITLE
Fix broken ToastProvider props table

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ For brevity:
 | Property                               | Description                                                                              |
 | -------------------------------------- | ---------------------------------------------------------------------------------------- |
 | autoDismissTimeout `number`            | Default `5000`. The time until a toast will be dismissed automatically, in milliseconds. |
-| autoDismiss `boolean`                  | Default: `false`. Whether or not to dismiss the toast automatically after a timeout. |
-
+| autoDismiss `boolean`                  | Default: `false`. Whether or not to dismiss the toast automatically after a timeout.     |
 | children `Node`                        | Required. Your app content.                                                              |
 | components `{ ToastContainer, Toast }` | Replace the underlying components.                                                       |
 | placement `PlacementType`              | Default `top-right`. Where, in relation to the viewport, to place the toasts.            |


### PR DESCRIPTION
Hi 👋 just noticed that the props table for the ToastProvider in the readme was broken - looks like there was an empty line that broke any rows after it. This PR should fix that.