### PR TITLE
Support multiple nested Contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ const FormWithToasts = () => {
     } else {
       addToast('Saved Successfully', { appearance: 'success' })
     }
-  }
+  };
 
   return <form onSubmit={onSubmit}>...</form>
-}
+};
 
 const App = () => (
   <ToastProvider>
@@ -49,36 +49,43 @@ For brevity:
 - `PlacementType` is equal to `'bottom-left' | 'bottom-center' | 'bottom-right' | 'top-left' | 'top-center' | 'top-right'`.
 - `TransitionState` is equal to `'entering' | 'entered' | 'exiting' | 'exited'`.
 
-| Property                               | Description                                                                              |
-| -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| autoDismissTimeout `number`            | Default `5000`. The time until a toast will be dismissed automatically, in milliseconds. |
-| autoDismiss `boolean`                  | Default: `false`. Whether or not to dismiss the toast automatically after a timeout. |
+| Property                    | Description                                                                              |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| autoDismissTimeout `number` | Default `5000`. The time until a toast will be dismissed automatically, in milliseconds. |
+| autoDismiss `boolean`       | Default: `false`. Whether or not to dismiss the toast automatically after a timeout.     |
 
-| children `Node`                        | Required. Your app content.                                                              |
-| components `{ ToastContainer, Toast }` | Replace the underlying components.                                                       |
-| placement `PlacementType`              | Default `top-right`. Where, in relation to the viewport, to place the toasts.            |
-| transitionDuration `number`            | Default `220`. The duration of the CSS transition on the `Toast` component.              |
+| children `Node` | Required. Your app content. |
+| components `{ ToastContainer, Toast }` | Replace the underlying components. |
+| placement `PlacementType` | Default `top-right`. Where, in relation to the viewport, to place the toasts. |
+| transitionDuration `number` | Default `220`. The duration of the CSS transition on the `Toast` component. |
+| name `string` | Default `default`. Provide a unique name when using [Nested Providers](#nested-providers). |
 
 ## Toast Props
 
-| Property                           | Description                                                        |
-| ---------------------------------- | ------------------------------------------------------------------ |
-| appearance                         | Required. One of `success`, `error`, `warning`, `info`             |
-| children                           | Required. The content of the toast notification.                   |
-| autoDismiss `boolean`              | Inherited from `ToastProvider` if not provided.                    |
-| autoDismissTimeout `number`        | Inherited from `ToastProvider`.                                    |
-| onDismiss: `Id => void`          | Passed in dynamically. Can be called in a custom toast to dismiss it.|
-| placement `PlacementType`          | Inherited from `ToastProvider`.                                    |
-| transitionDuration `number`        | Inherited from `ToastProvider`.                                    |
-| transitionState: `TransitionState` | Passed in dynamically.                                             |
+| Property                           | Description                                                           |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| appearance                         | Required. One of `success`, `error`, `warning`, `info`                |
+| children                           | Required. The content of the toast notification.                      |
+| autoDismiss `boolean`              | Inherited from `ToastProvider` if not provided.                       |
+| autoDismissTimeout `number`        | Inherited from `ToastProvider`.                                       |
+| onDismiss: `Id => void`            | Passed in dynamically. Can be called in a custom toast to dismiss it. |
+| placement `PlacementType`          | Inherited from `ToastProvider`.                                       |
+| transitionDuration `number`        | Inherited from `ToastProvider`.                                       |
+| transitionState: `TransitionState` | Passed in dynamically.                                                |
 
 ## Hook
 
 The `useToast` hook has the following signature:
 
 ```jsx
-const { addToast, removeToast, removeAllToasts, updateToast, toastStack } = useToasts();
+const { addToast, removeToast, removeAllToasts, updateToast, toastStack } = useToasts(options);
 ```
+
+`options` passed to `useToasts` are:
+
+| Option        | Description                                                                                |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| name `string` | Default `default`. Provide a unique name when using [Nested Providers](#nested-providers). |
 
 The `addToast` method has three arguments:
 
@@ -104,8 +111,8 @@ The `toastStack` is an array of objects representing the current toasts, e.g.
 ```jsx
 [
   { content: 'Something went wrong', id: 'generated-string', appearance: 'error' },
-  { content: 'Item saved', id: 'generated-string', appearance: 'success' }
-]
+  { content: 'Item saved', id: 'generated-string', appearance: 'success' },
+];
 ```
 
 ## Replaceable Components
@@ -134,6 +141,34 @@ export const MyCustomToast = ({ children, ...props }) => (
   <DefaultToast {...props}>
     <SomethingSpecial>{children}</SomethingSpecial>
   </DefaultToast>
+);
+```
+
+## Nested Providers
+
+Displaying individual toasts differently is done using nested `<ToastProvider>`s.
+
+For example, [the docs
+page](https://jossmac.github.io/react-toast-notifications) displays both
+"notification" style & "snack bar" style toasts simultaneously on the same page.
+
+Nested Providers must be given a unique `name` prop, which is then also passed
+to the `<ToastConsumer>` component or `useToasts()` hook.
+
+```jsx
+import { ToastProvider, ToastConsumer } from 'react-toast-notifications';
+
+const App = () => (
+  <ToastProvider>
+    <ToastProvider name="snack">
+      <ToastConsumer>
+        {({ add }) => <button onClick={() => add('A toast')}>Add Toast</button>}
+      </ToastConsumer>
+      <ToastConsumer name="snack">
+        {({ add }) => <button onClick={() => add('A snack')}>Add Snack</button>}
+      </ToastConsumer>
+    </ToastProvider>
+  </ToastProvider>
 );
 ```
 

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -208,49 +208,50 @@ function App() {
 
   return (
     <ToastProvider>
-      <ConnectivityListener />
-      <Section area="intro">
-        <Container>
-          <Header>
-            <Repo href={repoUrl}>
-              <Icon role="img">🍞</Icon>
-              <span>React Toast Notifications</span>
-            </Repo>
-            <GithubLogo href={repoUrl} target="_blank" />
-          </Header>
+      <ToastProvider
+        name="snack"
+        autoDismiss
+        autoDismissTimeout={6000}
+        components={{ Toast: Snack }}
+        placement="bottom-center"
+      >
+        <ConnectivityListener />
+        <Section area="intro">
+          <Container>
+            <Header>
+              <Repo href={repoUrl}>
+                <Icon role="img">🍞</Icon>
+                <span>React Toast Notifications</span>
+              </Repo>
+              <GithubLogo href={repoUrl} target="_blank" />
+            </Header>
 
-          <Body>
-            <Toasts />
-          </Body>
+            <Body>
+              <Toasts />
+            </Body>
 
-          <Footer>
-            <div>
-              <span>by </span>
-              <a href="https://twitter.com/jossmackison" target="_blank">
-                @jossmac
-              </a>
-            </div>
-            <div>
-              paragraphs from{' '}
-              <a href="http://www.cupcakeipsum.com" target="_blank">
-                Cupcake Ipsum
-              </a>{' '}
-            </div>
-          </Footer>
-        </Container>
-      </Section>
-      {/*
+            <Footer>
+              <div>
+                <span>by </span>
+                <a href="https://twitter.com/jossmackison" target="_blank">
+                  @jossmac
+                </a>
+              </div>
+              <div>
+                paragraphs from{' '}
+                <a href="http://www.cupcakeipsum.com" target="_blank">
+                  Cupcake Ipsum
+                </a>{' '}
+              </div>
+            </Footer>
+          </Container>
+        </Section>
+        {/*
         ==============================
         CONFIGURATION
         ==============================
       */}
-      <Section area="config">
-        <ToastProvider
-          autoDismiss
-          autoDismissTimeout={6000}
-          components={{ Toast: Snack }}
-          placement="bottom-center"
-        >
+        <Section area="config">
           <Container>
             <Body>
               <StretchGroup reverse>
@@ -260,7 +261,7 @@ function App() {
                     <p>
                       Replace or configure any part of the notification system.
                     </p>
-                    <ToastConsumer>
+                    <ToastConsumer name="snack">
                       {({ add, toasts }) => (
                         <Button
                           appearance="snack"
@@ -292,39 +293,42 @@ const App = () => (
               </StretchGroup>
             </Body>
           </Container>
-        </ToastProvider>
-      </Section>
-      {/*
+        </Section>
+        {/*
         ==============================
         EXAMPLE
         ==============================
       */}
-      <Section area="example">
-        <Container>
-          <Body>
-            <StretchGroup>
-              <ContentBlock align="left">
-                <Title>Let&apos;s get real.</Title>
-                <div>
-                  <p>
-                    You&apos;re probably not firing off notifications
-                    haphazardly, from some random buttons in your app.*
-                  </p>
-                  <p>
-                    To see an example of how you might use this IRL, toggle the{' '}
-                    <code>Offline</code> checkbox in the Network pane of your
-                    dev tools. If you're on mobile, just turn on flight-mode.
-                  </p>
-                  <p>
-                    <small>* It's totally cool if you are, no judgement.</small>
-                  </p>
-                </div>
-              </ContentBlock>
-              <CodeBlock>{exampleText}</CodeBlock>
-            </StretchGroup>
-          </Body>
-        </Container>
-      </Section>
+        <Section area="example">
+          <Container>
+            <Body>
+              <StretchGroup>
+                <ContentBlock align="left">
+                  <Title>Let&apos;s get real.</Title>
+                  <div>
+                    <p>
+                      You&apos;re probably not firing off notifications
+                      haphazardly, from some random buttons in your app.*
+                    </p>
+                    <p>
+                      To see an example of how you might use this IRL, toggle
+                      the <code>Offline</code> checkbox in the Network pane of
+                      your dev tools. If you're on mobile, just turn on
+                      flight-mode.
+                    </p>
+                    <p>
+                      <small>
+                        * It's totally cool if you are, no judgement.
+                      </small>
+                    </p>
+                  </div>
+                </ContentBlock>
+                <CodeBlock>{exampleText}</CodeBlock>
+              </StretchGroup>
+            </Body>
+          </Container>
+        </Section>
+      </ToastProvider>
     </ToastProvider>
   );
 }

--- a/src/types.js
+++ b/src/types.js
@@ -6,6 +6,7 @@ export type AppearanceTypes = 'error' | 'info' | 'success' | 'warning';
 export type Id = string;
 export type Callback = Id => void;
 export type Options = {
+  id?: Id,
   appearance: AppearanceTypes,
   autoDismiss?: boolean,
   onDismiss?: Callback,
@@ -25,5 +26,5 @@ export type Placement =
   | 'top-center'
   | 'top-right';
 
-export type ToastType = Options & { appearance: AppearanceTypes, content: Node, id: Id };
+export type ToastType = { content: Node, id: Id } & Options;
 export type ToastsType = Array<ToastType>;

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,3 +6,11 @@ export function generateUEID() {
   second = ('000' + second.toString(36)).slice(-3);
   return first + second;
 }
+export function omit(obj, keyToOmit) {
+  return Object.entries(obj).reduce((memo, [key, value]) => {
+    if (key !== keyToOmit) {
+      memo[key] = value;
+    }
+    return memo;
+  }, {});
+}


### PR DESCRIPTION
From the updated docs:

Displaying individual toasts differently is done using nested `<ToastProvider>`s.

For example, [the docs page](https://jossmac.github.io/react-toast-notifications) displays both "notification" style & "snack bar" style toasts simultaneously on the same page.

Nested Providers must be given a unique `name` prop, which is then also passed to the `<ToastConsumer>` component or `useToasts()` hook.

```jsx
import { ToastProvider, ToastConsumer } from 'react-toast-notifications';
const App = () => (
  <ToastProvider>
    <ToastProvider name="snack">
      <ToastConsumer>
        {({ add }) => <button onClick={() => add('A toast')}>Add Toast</button>}
      </ToastConsumer>
      <ToastConsumer name="snack">
        {({ add }) => <button onClick={() => add('A snack')}>Add Snack</button>}
      </ToastConsumer>
    </ToastProvider>
  </ToastProvider>
);
```