### PR TITLE
Fix broken table format in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ For brevity:
 | Property                               | Description                                                                              |
 | -------------------------------------- | ---------------------------------------------------------------------------------------- |
 | autoDismissTimeout `number`            | Default `5000`. The time until a toast will be dismissed automatically, in milliseconds. |
-| autoDismiss `boolean`                  | Default: `false`. Whether or not to dismiss the toast automatically after a timeout. |
-
+| autoDismiss `boolean`                  | Default: `false`. Whether or not to dismiss the toast automatically after a timeout.     |
 | children `Node`                        | Required. Your app content.                                                              |
 | components `{ ToastContainer, Toast }` | Replace the underlying components.                                                       |
 | placement `PlacementType`              | Default `top-right`. Where, in relation to the viewport, to place the toasts.            |


### PR DESCRIPTION
Updating the readme to fix the broken markdown table

## Before

<img src="https://user-images.githubusercontent.com/5829188/89668518-b57e4e80-d892-11ea-9708-0716f88160fb.png" width="600px" />

## After

<img src="https://user-images.githubusercontent.com/5829188/89668570-d21a8680-d892-11ea-8c6a-2ab2bbfdcb24.png" width="600px" />

