### PR TITLE
fixes scrollbar appearing on exit animation

### DIFF
--- a/src/ToastElement.js
+++ b/src/ToastElement.js
@@ -30,7 +30,7 @@ const A11yText = ({ tag: Tag, ...props }) => (
       border: 0,
       clip: 'rect(1px, 1px, 1px, 1px)',
       height: 1,
-      overflow: 'hidden',
+      overflow: 'hidden !important',
       padding: 0,
       position: 'absolute',
       whiteSpace: 'nowrap',


### PR DESCRIPTION
I noticed another ticket about this issue and I saw the same thing in my project (Chrome & Firefox). 

It is also present on your demo page. If you stare at the toast, as it exits you'll see tiny scroll bar the height of the toast for a split second. I'm not sure why your existing overflow: 'hidden' doesn't do the trick, but it's safe to brute force it with an "!important."