### PR TITLE
Appearance in options is mandatory

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ export interface Options {
     onDismiss?: (id: string) => void;
 }
 
-export type AddToast = (content: ReactNode, options?: Options, callback?: (id: string) => void) => void;
+export type AddToast = (content: ReactNode, options: Options, callback?: (id: string) => void) => void;
 
 export type RemoveToast = (id: string, callback?: (id: string) => void) => void;
 


### PR DESCRIPTION
Makes it more clear when using typescript, that appearance in options is mandatory. Should fix issues like #136, #23 for typescript users.