### PR TITLE
Update toastWidth in toastElemt.js

### DIFF
--- a/src/ToastElement.js
+++ b/src/ToastElement.js
@@ -20,7 +20,7 @@ import { NOOP } from './utils';
 // common
 export const borderRadius = 4;
 export const gutter = 8;
-export const toastWidth = 360;
+export const toastWidth = 300;
 export const shrinkKeyframes = keyframes`from { height: 100%; } to { height: 0% }`;
 
 // a11y helper


### PR DESCRIPTION
It is the best used library among various react toasts open sources.

Currently, I am making a website with nextjs, but if the mobileS size is the same as iphone5, the toast width is 360, so it will not appear on the screen.

Therefore, I modified the toastwidth to 300. Thank you.