### PR TITLE
Add style prop to ToastContainer Props in type declarations file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { ReactNode, ComponentType } from 'react';
+import { ReactNode, ComponentType, CSSProperties } from 'react';
 
 export type AppearanceTypes = 'error' | 'info' | 'success' | 'warning';
 
@@ -37,6 +37,7 @@ export interface ToastConsumerProps {
 export interface ToastContainerProps {
     children: ReactNode;
     className?: string;
+    style?: CSSProperties;
     hasToasts: boolean;
     placement: Placement;
 }


### PR DESCRIPTION
This fixes the following issue when using TypeScript:

```tsx
import { DefaultToastContainer, ToastContainerProps } from 'react-toast-notifications'

export const CustomToastContainer: React.FC = (props) => (
  <DefaultToastContainer style={{ marginTop: '20px' }} {...props} />
)
```

```ts
No overload matches this call.
  Overload 1 of 2, '(props: PropsWithChildren<ToastContainerProps>, context?: any): ReactElement<any, any> | Component<ToastContainerProps, any, any> | null', gave the following error.
    Type '{ children: ReactNode; className?: string | undefined; hasToasts: boolean; placement: Placement; style: { marginTop: string; }; }' is not assignable to type 'IntrinsicAttributes & ToastContainerProps & { children?: ReactNode; }'.
      Property 'style' does not exist on type 'IntrinsicAttributes & ToastContainerProps & { children?: ReactNode; }'.
  Overload 2 of 2, '(props: ToastContainerProps, context?: any): ReactElement<any, any> | Component<ToastContainerProps, any, any> | null', gave the following error.
    Type '{ children: ReactNode; className?: string | undefined; hasToasts: boolean; placement: Placement; style: { marginTop: string; }; }' is not assignable to type 'IntrinsicAttributes & ToastContainerProps'.
      Property 'style' does not exist on type 'IntrinsicAttributes & ToastContainerProps'.ts(2769)
```

Since the component does not expect a `style` prop, that is then passed down to `div`

```tsx
export const ToastContainer = ({
  hasToasts,
  placement,
  ...props
}: ToastContainerProps) => (
  <div
    className="react-toast-notifications__container"
    css={{
      boxSizing: 'border-box',
      maxHeight: '100%',
      maxWidth: '100%',
      overflow: 'hidden',
      padding: gutter,
      pointerEvents: hasToasts ? null : 'none',
      position: 'fixed',
      zIndex: 1000,
      ...placements[placement],
    }}
    {...props} // here
  />
);
```