### PR TITLE
Allow custom toast component with custom props.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export interface ToastProviderProps {
     children: ReactNode;
     components?: {
         ToastContainer?: ComponentType<ToastContainerProps>;
-        Toast?: ComponentType<ToastProps>;
+        Toast?: ComponentType<ToastProps | any>;
     };
     placement?: Placement;
     transitionDuration?: number;


### PR DESCRIPTION
This change loosen the toast type to allow any custom toast prop that doesn't extend the `ToastProp` to be used and assigned to the `components.Toast` prop.